### PR TITLE
<endian.h> is <sys/endian.h> in FreeBSD

### DIFF
--- a/csiphash.c
+++ b/csiphash.c
@@ -34,6 +34,8 @@
 #if defined(__APPLE__)
 #  include <libkern/OSByteOrder.h>
 #  define le64toh(x) OSSwapLittleToHostInt64(x)
+#elif defined(__FreeBSD__)
+#  include <sys/endian.h>
 #else
 #  include <endian.h>
 #endif


### PR DESCRIPTION
I was writing a Perl module called Digest::SipHash using your csiphash.c and found the glitch. 

Dan
